### PR TITLE
fix: createRoot in index instead of render

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import './index.st.css';
 import App from './app';
 
-ReactDOM.render(
+createRoot(document.body.appendChild(document.createElement('div'))).render(
     <React.StrictMode>
         <App />
-    </React.StrictMode>,
-    document.body.appendChild(document.createElement('div'))
+    </React.StrictMode>
 );


### PR DESCRIPTION
> ReactDOM.render is no longer supported in React 18. Use createRoot instead. Until you switch to the new API, your app will behave as if it’s running React 17.

Following recent React 18 changes:[ _Updates to Client Rendering APIs_](https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-client-rendering-apis), I changed `index.tsx` accordingly.